### PR TITLE
Added CompatHelper docs-subdir

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,4 +13,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs = ["", "docs"])'


### PR DESCRIPTION
According to the [CompatHerlper.jl-Docs](https://juliaregistries.github.io/CompatHelper.jl/dev/options/) this should add support for the docs directory as discussed in #5 