### PR TITLE
Add missing .git extension to deploydocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,7 @@ makedocs(bib;
 )
 
 deploydocs(;
-    repo = "github.com/bernd1995/LatSpec.jl",
+    repo = "github.com/bernd1995/LatSpec.jl.git",
     target = "build",
     push_preview = true
 )


### PR DESCRIPTION
It seems that we need to specify the git-files in order for the deployment of the docs to work correctly.