### PR TITLE
[WIP] Added some math functions and helpers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,14 +8,13 @@ DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 LsqFit = "2fda8390-95c7-5789-9bda-21331edee243"
-Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-Plots = "1.15"
-LsqFit = "0.12"
 LaTeXStrings = "1.2"
+LsqFit = "0.12"
 julia = "1"
 
 [extras]

--- a/src/LatSpec.jl
+++ b/src/LatSpec.jl
@@ -17,7 +17,7 @@ export
     theories,
     theory_name
 
-export DataPoint, ±, value, staterr, syserr, relstaterr, statbounds
+export DataPoint, ±, value, err, relerr, bounds,otherfun
 
 const CURRENT_THEORY = CurrentTheory(:none)
 

--- a/src/LatSpec.jl
+++ b/src/LatSpec.jl
@@ -17,7 +17,7 @@ export
     theories,
     theory_name
 
-export DataPoint, ±, value, staterr, syserr
+export DataPoint, ±, value, staterr, syserr, relstaterr, statbounds
 
 const CURRENT_THEORY = CurrentTheory(:none)
 

--- a/src/datapoint.jl
+++ b/src/datapoint.jl
@@ -1,21 +1,20 @@
 ## New Type: DataPoint
 # Struct for carrying statistic and systematic uncertainty of a DataPoint
 """
-    DataPoint(x,stat,sys)
-Parametric type that stores a value and its respective statistical and systematic
-uncertainties. The uncertainties can either be numbers for symmetric uncertainties
-or a tuple for lower and upper bounds. It can be created by either providing
-positional arguments ( e.g. `DataPoint(1.0,0.1,0.2)` or
-`DataPoint(1.0,(0.09,0.11),(0.21,0.19))`) or using the keyword arguments `stat`
-and `sys` ( e.g. `DataPoint(1.0,stat=0.1,sys=0.2) . If only one uncertainty is
-provided without a keyword, it is assumed to be statistical.
+    DataPoint(x,err)
+Parametric type that stores a value and its respective statistical uncertainty.
+The uncertainty can either be a number for a symmetric uncertainty or a tuple
+for lower and upper bounds. It can be created by either providing
+positional arguments (e.g. `DataPoint(1.0,0.1)` or `DataPoint(1.0,(0.09,0.11))`)
+or by using the keyword arguments `lower` and `upper`
+(e.g. `DataPoint(1.0,lower=0.1,upper=0.2). If only one keyword is given, the
+other is assumed to be zero.
 
-It can also be created by using the ± symbol, e.g. `x ± stat` and `x ± stat ± sys`.
+It can also be created by using the ± symbol, e.g. `x ± err`.
 """
 struct DataPoint{T<:Number} <: Number
     val::T
-    stat_err::Tuple{T,T}
-    sys_err::Tuple{T,T}
+    err::Tuple{T,T}
 end
 """
     value(x::DataPoint)
@@ -23,21 +22,15 @@ Returns the mean value of the data point.
 """
 value(x::DataPoint) = x.val
 """
-    staterr(x::DataPoint)
+    err(x::DataPoint)
 Returns the statistical uncertainty of the data point as a tuple of upper and
 lower bounds. If none is provided it will default to zero.
 """
-staterr(x::DataPoint) = x.stat_err
-"""
-    syserr(x::DataPoint)
-Returns the systematic uncertainty of the data point as a tuple of upper and
-lower bounds. If none is provided it will default to zero.
-"""
-syserr(x::DataPoint) = x.sys_err
+err(x::DataPoint) = x.err
 
-relstaterr(x::DataPoint) = x.stat_err / abs(x.val)
+relerr(x::DataPoint) = x.err / abs(x.val)
 
-statbounds(x::DataPoint) = x.val .+ (-1,1).*x.stat_err
+bounds(x::DataPoint) = @. x.val + (-1,1)*x.err
 # Helper functions
 _to_tuple(x::T where T<:Number) = (x,x)
 _to_tuple(x::Tuple) = promote(x...)
@@ -45,38 +38,36 @@ _check_error_positivity(err) = all(x -> (π/2 >= angle(x)>=0), err)
 
 ## Constructors
 # default constructor
-DataPoint{T}(x = zero(T), stat = (zero(T), zero(T)), sys = (zero(T),zero(T))) where {T} = DataPoint{T}(x, stat, sys)
-DataPoint() = DataPoint{Float64}()
-# dispatch constructor
-DataPoint(x::Number, stat, sys = zero(x)) = DataPoint(x, stat = stat, sys = sys)
-# keyword constructor for integers (ceils uncertainties)
-# function DataPoint(x::Integer; stat=zero(x), sys=zero(x))
-#     @assert _check_error_positivity(stat) && _check_error_positivity(sys) "Only use positive uncertainties!"
-#     stat = _to_tuple(stat)
-#     sys = _to_tuple(sys)
-#     T = typeof(x)
-#     DataPoint(x,T.(ceil.(stat)),T.(ceil.(sys)))
-# end
+DataPoint(x::T, err=zero(T)) where {T} = DataPoint{T}(x, err=err)
+DataPoint() = DataPoint{Float64}(0.0)
+# keyword constructor for separate errors
+#function DataPoint{T}()
 # keyword constructor for real numbers
-function DataPoint(x::Number; stat=zero(x), sys=zero(x))
-    @assert _check_error_positivity(stat) && _check_error_positivity(sys) "Only use positive uncertainties!"
-    stat = _to_tuple(stat)
-    sys = _to_tuple(sys)
-    T = promote_type(typeof(x), eltype(stat), eltype(sys))
-    DataPoint(T(x),T.(stat),T.(sys))   # with keywords
+function DataPoint{T}(x::T; err=zero(T)) where {T <: Number}
+    @assert _check_error_positivity(err) "Only use positive uncertainties!"
+    err = _to_tuple(err)
+    U = promote_type(typeof(x), eltype(err))
+    DataPoint{U}(x,err)
 end
 # Operators for construction
 const ±(val, err) = DataPoint(val, err)
-const ±(val, err::NamedTuple) = DataPoint(val, hasproperty(err,:stat) ? err.stat : zero(val), hasproperty(err,:sys) ? err.sys : zero(val))
-const ±(D::DataPoint, sys) = DataPoint(D.val, D.stat_err, sys)
+#const ±(val, err::NamedTuple) = DataPoint(val, hasproperty(err,:stat) ? err.stat : zero(val), hasproperty(err,:sys) ? err.sys : zero(val))
+
 
 ## Convert DataPoint-types
-convert(::Type{DataPoint{T}}, D::DataPoint) where {T} = DataPoint{T}(T(D.val),T.(D.stat_err), T.(D.sys_err))
-convert(::Type{DataPoint{T}}, D::DataPoint) where {T<:Integer} = DataPoint{T}(T(D.val),T.(ceil.(D.stat_err)), T.(ceil.(D.sys_err)))
+convert(::Type{DataPoint{T}}, D::DataPoint) where {T} = DataPoint{T}(T(D.val),T.(D.err))
+convert(::Type{DataPoint{T}}, D::DataPoint) where {T<:Integer} = DataPoint{T}(T(D.val),T.(ceil.(D.err)))
 
 ## DataPoint math
-Base.:/(D::DataPoint, s::T) where {T <: Number} = DataPoint(D.val/s,D.stat_err/s,D.sys_err/s)
-Base.:*(D::DataPoint, s::T) where {T <: Number} = DataPoint(D.val*s,D.stat_err*s,D.sys_err*s)
+Base.:/(D::DataPoint, s::T) where {T <: Number} = DataPoint(D.val/s,D.err/s)
+function Base.:/(D1::DataPoint, D2::DataPoint)
+    err = abs.(D1.err/D2.val) .+ abs.(D1.val/D2.val^2.0 .* D2.err)
+    DataPoint(D1.val/D2.val,err)
+end
+Base.:*(D::DataPoint, s::T) where {T <: Number} = DataPoint(D.val*s,D.err*s)
+function Base.log(D::DataPoint, kws...)
+    DataPoint(log(D.val, kws...),abs.(D.err./D.val))
+end
 
 ## Pretty-printing
 # Printing of results
@@ -84,15 +75,13 @@ function show(io::IO, ::MIME"text/plain", D::DataPoint{T}; drop::Bool = true) wh
     println(io, "DataPoint{",T,"}:")
     print(io, "Value → ")
     show(io, D.val)
-    if (!drop || D.stat_err != (0,0)) print(io, "\tStatistic unc. → ", (-1,1) .* D.stat_err); end
-    if (!drop || D.sys_err != (0,0)) print(io, "\tSystematic unc. → ", (-1,1) .* D.sys_err); end
+    if (!drop || D.err != (0,0)) print(io, "\tStatistic unc. → ", (-1,1) .* D.err); end
 end
 
 # Print(ln)-function and Juno-Workspace
 function show(io::IO, D::DataPoint{T}) where {T}
     if get(io, :compact, false)     # e.g. in arrays
-        print(io, D.val, " ± ", D.stat_err)
-        print(io, " ± ", D.sys_err)
+        print(io, D.val, " ± ", D.err)
     else
         show(io, MIME("text/plain"), D; drop = false)
     end

--- a/test/datapoint.jl
+++ b/test/datapoint.jl
@@ -12,7 +12,7 @@
     # Check Constructors
     # Right hand side should always call the base cosntructor
     @testset verbose=true "DataPoint    " begin
-        @test (local D = DataPoint(); all(isnan.([D.val D.stat_err... D.sys_err...])))
+        @test (local D = DataPoint();  (local D = DataPoint(); all([D.val D.stat_err... D.sys_err...] .≈ 0.0)))
         # Check handling of tuples and numbers as input
         @testset "dispatch    " begin
             # uncertainties are numbers
@@ -112,11 +112,11 @@
         D3 = DataPoint(1.0, sys = (4,5))
 
         print(io, D1)
-        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tStatistic unc. → (2.0, -3.0)\tSystematic unc. → (0.0, -0.0)"
+        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tStatistic unc. → (-2.0, 3.0)\tSystematic unc. → (-0.0, 0.0)"
         print(io, D2)
-        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tStatistic unc. → (2.0, -3.0)\tSystematic unc. → (4.0, -5.0)"
+        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tStatistic unc. → (-2.0, 3.0)\tSystematic unc. → (-4.0, 5.0)"
         print(io, D3)
-        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tStatistic unc. → (0.0, -0.0)\tSystematic unc. → (4.0, -5.0)"
+        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tStatistic unc. → (-0.0, 0.0)\tSystematic unc. → (-4.0, 5.0)"
 
         print(IOContext(io, :compact => true), D1)
         @test String(take!(io)) == "1.0 ± (2.0, 3.0) ± (0.0, 0.0)"
@@ -126,10 +126,10 @@
         @test String(take!(io)) == "1.0 ± (0.0, 0.0) ± (4.0, 5.0)"
 
         show(io, MIME("text/plain"), D1)
-        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tStatistic unc. → (2.0, -3.0)"
+        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tStatistic unc. → (-2.0, 3.0)"
         show(io, MIME("text/plain"), D2)
-        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tStatistic unc. → (2.0, -3.0)\tSystematic unc. → (4.0, -5.0)"
+        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tStatistic unc. → (-2.0, 3.0)\tSystematic unc. → (-4.0, 5.0)"
         show(io, MIME("text/plain"), D3)
-        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tSystematic unc. → (4.0, -5.0)"
+        @test String(take!(io)) == "DataPoint{Float64}:\nValue → 1.0\tSystematic unc. → (-4.0, 5.0)"
     end
 end


### PR DESCRIPTION
Switched the order of upper and lower error for datapoints because it seems more reasonable to use it in this order `(lower,upper)`.

Added some default constructors and type-specific ones which are needed when calling some functions with `DataPoint` types as an argument.

Need an opinion by @fzierler on how we treat the systematic uncertainties for things like relative error and region of datapoints.